### PR TITLE
fix link reference definition titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/markdown",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "module",
   "description": "A tiny, fast, deterministic Markdown renderer for blogs and documentation.",
   "license": "MIT",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -424,9 +424,15 @@ function extractDefinitions(lines: string[]) {
         continue
       }
 
-      const definition = line.match(/^ {0,3}\[([^\]\n]+)\]:[ \t]*(\S+)[ \t]*$/)
+      const definition = line.match(
+        /^ {0,3}\[([^\]\n]+)\]:[ \t]*(\S+)(?:[ \t]+(?:"([^"]*)"|'([^']*)'|\(([^)]*)\)))?[ \t]*$/,
+      )
       if (definition) {
-        references[normalizeReferenceLabel(definition[1]!)] = { href: definition[2]!.replace(/^<|>$/g, '') }
+        const title = definition[3] ?? definition[4] ?? definition[5]
+        references[normalizeReferenceLabel(definition[1]!)] = {
+          href: definition[2]!.replace(/^<|>$/g, ''),
+          ...(title !== undefined ? { title } : {}),
+        }
         index++
         continue
       }

--- a/tests/conformance.test.ts
+++ b/tests/conformance.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { commonMarkBaseline, commonMarkVersion, evaluateCommonMark } from '../scripts/conformance-data.js'
+import { renderHtml } from '../src/index.js'
 
 describe(`CommonMark ${commonMarkVersion} compatibility accounting`, () => {
   const result = evaluateCommonMark()
@@ -12,5 +13,17 @@ describe(`CommonMark ${commonMarkVersion} compatibility accounting`, () => {
   it('never lowers aggregate compatibility while allowing deliberate improvements', () => {
     expect(result.total).toBe(652)
     expect(result.passing.length).toBeGreaterThanOrEqual(commonMarkBaseline.length)
+  })
+
+  it('supports every CommonMark link reference title delimiter', () => {
+    const markdown = `[single]: /single 'Single title'
+[double]: /double "Double title"
+[parenthesized]: /parenthesized (Parenthesized title)
+
+[one][single] [two][double] [three][parenthesized]`
+
+    expect(renderHtml(markdown)).toBe(
+      '<p><a href="/single" title="Single title">one</a> <a href="/double" title="Double title">two</a> <a href="/parenthesized" title="Parenthesized title">three</a></p>',
+    )
   })
 })

--- a/tests/markdown.test.tsx
+++ b/tests/markdown.test.tsx
@@ -106,6 +106,10 @@ export function Demo() {
 </section>`)
   })
 
+  it('omits tanstack.com section markers written as link reference definitions', () => {
+    expect(renderHtml("[//]: # 'ExampleUI1'")).toBe('')
+  })
+
   it('renders repeated footnotes without duplicate ids', () => {
     const markdown = `One[^note], then again[^note].
 


### PR DESCRIPTION
## What changed

- recognize CommonMark optional titles on link reference definitions using single quotes, double quotes, or parentheses
- preserve definition titles on resolved reference links
- omit tanstack.com section markers such as `[//]: # 'ExampleUI1'` from rendered output
- bump the package to `0.0.9`

## Root cause

Definition extraction only accepted `[label]: destination`, so a valid title caused the entire definition line to fall through as paragraph content.

## Validation

- `pnpm test` (81 tests)
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm pack --dry-run`
