### PR TITLE
docs: use the dynamic README header endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+<div align="center">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://tanstack.com/api/readme/markdown.png?theme=dark"
+    />
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://tanstack.com/api/readme/markdown.png"
+    />
+    <img
+      src="https://tanstack.com/api/readme/markdown.png"
+      alt="TanStack Markdown"
+      width="900"
+    />
+  </picture>
+</div>
+
 # TanStack Markdown
 
 A tiny, fast, deterministic Markdown parser and renderer for blogs and documentation.


### PR DESCRIPTION
Adopts the dynamic README header endpoint added in TanStack/tanstack.com#1076,
which is merged and live.

README banners now point a `<picture>` at `https://tanstack.com/api/readme/`
instead of a committed PNG. The endpoint renders 1800x450 in light and dark, so
a branding change lands in every README at once and dark-mode readers get a
dark banner.

This repo had no banner at all. Adding one for parity with the other library repos.

## Notes

- Light and dark are served through `<picture>`, per [GitHub's guidance](https://github.blog/developer-skills/github/how-to-make-your-images-in-markdown-on-github-adjust-for-dark-mode-and-light-mode/). The trailing `<img>` stays the light variant, as the fallback for renderers that ignore `<picture>` (npm, most editors).
- Only packages a user installs directly get a banner. Private and internal packages are deliberately left alone.

## Verification

Every URL in this diff was requested against the live endpoint and returned
`200 image/png` at 1800x450. `git grep` confirms no README still references
the deleted asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered, responsive banner to the README.
  * Added dark- and light-theme image support with accessible Markdown text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->